### PR TITLE
Release v0.3.0

### DIFF
--- a/app_info.go
+++ b/app_info.go
@@ -3,7 +3,7 @@ package webhook
 import corev1 "k8s.io/api/core/v1"
 
 // Version is automatically bumped on release branches
-const version = "0.2.0"
+const version = "0.3.0"
 
 var appInfo = []corev1.EnvVar{
 	{

--- a/deploy/aws-lambda/README.md
+++ b/deploy/aws-lambda/README.md
@@ -4,7 +4,7 @@ You can deploy the webhook to AWS Lambda and activate it in your Kubernetes clus
 
 ```terraform
 module "secrethub_mutating_webhook" {
-  source = "github.com/secrethub/secrethub-kubernetes-mutating-webhook//deploy/aws-lambda?ref=v0.2.0"
+  source = "github.com/secrethub/secrethub-kubernetes-mutating-webhook//deploy/aws-lambda?ref=v0.3.0"
 }
 ```
 

--- a/deploy/aws-lambda/version.tf
+++ b/deploy/aws-lambda/version.tf
@@ -4,5 +4,5 @@ variable "webhook_version" {
   # Default version will get bumped automatically on release PRs,
   # so updating the module will also update the webhook version
   # if the module doesn't override the variable.
-  default = "0.2.0"
+  default = "0.3.0"
 }


### PR DESCRIPTION
### Added

- Terraform module to deploy the webhook to AWS Lambda (https://github.com/secrethub/secrethub-kubernetes-mutating-webhook/pull/10)

### Changed

- Support both `admissionregistration.k8s.io/v1` and `admissionregistration.k8s.io/v1beta1` (https://github.com/secrethub/secrethub-kubernetes-mutating-webhook/pull/12)